### PR TITLE
Fix None type comparison by pytest

### DIFF
--- a/pbxplore/tests/test_functions.py
+++ b/pbxplore/tests/test_functions.py
@@ -252,7 +252,7 @@ class TestChainClass(object):
         Tests for get_phi_psi_angles()
         """
         phi_psi = chain.get_phi_psi_angles()
-        assert angles["phi"] == pytest.approx(phi_psi[resid]["phi"])
+        assert (angles["phi"] is None and phi_psi[resid]["phi"] is None) or angles["phi"] == pytest.approx(phi_psi[resid]["phi"])
 
     def test_set_coordinates(self, chain):
         """


### PR DESCRIPTION
Two tests were failing because of pytest.approx() function on None type variables which is unsupported.
Now tests return `<ExitCode.OK: 0>`